### PR TITLE
Fix 16 to 8-bit conversion

### DIFF
--- a/dominantcolor.go
+++ b/dominantcolor.go
@@ -88,7 +88,7 @@ func Find(img image.Image) color.RGBA {
 			if a == 0 {
 				continue
 			}
-			r, g, b := uint8(ri/255), uint8(gi/255), uint8(bi/255)
+			r, g, b := uint8(ri/0x101), uint8(gi/0x101), uint8(bi/0x101)
 			// Check to see if we have seen this color before.
 			colorUnique = !clusters.ContainsCentroid(r, g, b)
 			// If we have a unique color set the center of the cluster to
@@ -113,7 +113,7 @@ func Find(img image.Image) color.RGBA {
 				if a == 0 {
 					continue
 				}
-				r, g, b := uint8(ri/255), uint8(gi/255), uint8(bi/255)
+				r, g, b := uint8(ri/0x101), uint8(gi/0x101), uint8(bi/0x101)
 				// Figure out which cluster this color is closest to in RGB space.
 				closest := clusters.Closest(r, g, b)
 				closest.AddPoint(r, g, b)


### PR DESCRIPTION
8-bit values are multiplied by 0x101 to make into 16 bit values in the rage 0-65535 so need to be divided by the same in reverse. Values that just overflowed 8-bits (256, 257) could turn from bright red, for instance, to no red at all which then caused anomalies in the output.

see: https://blog.golang.org/go-image-package